### PR TITLE
userとtaskのcreateとselectを追加、taskテーブルのuser_idカラムの型をuuidで明示的に指定する形に変更

### DIFF
--- a/app/graphql/mutations/create_task.rb
+++ b/app/graphql/mutations/create_task.rb
@@ -1,0 +1,18 @@
+module Mutations
+  class CreateTask < BaseMutation
+    field :task, Types::TaskType, null: true
+
+    argument :title, String, required: false
+    argument :content, String, required: false
+    argument :user_id, String, required: true
+
+    def resolve(**args)
+      user = User.find(args[:user_id])
+      task = user.tasks.build(title: args[:title], content: args[:content])
+      task.save
+      {
+        task: task
+      }
+    end
+  end
+end

--- a/app/graphql/mutations/create_user.rb
+++ b/app/graphql/mutations/create_user.rb
@@ -1,0 +1,14 @@
+module Mutations
+  class CreateUser < BaseMutation
+    field :user, Types::UserType, null: true
+
+    argument :email, String, required: true
+
+    def resolve(**args)
+      user = User.create!(args)
+      {
+        user: user
+      }
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -2,11 +2,7 @@
 
 module Types
   class MutationType < Types::BaseObject
-    # TODO: remove me
-    field :test_field, String, null: false,
-                               description: 'An example field added by the generator'
-    def test_field
-      'Hello World'
-    end
+    field :create_task, mutation: Mutations::CreateTask
+    field :create_user, mutation: Mutations::CreateUser
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -9,11 +9,14 @@ module Types
     # Add root-level fields here.
     # They will be entry points for queries on your schema.
 
-    # TODO: remove me
-    field :test_field, String, null: false,
-                               description: 'An example field added by the generator'
-    def test_field
-      'Hello World!'
+    field :users, [Types::UserType], null: false
+    def users
+      User.all
+    end
+
+    field :tasks, [Types::TaskType], null: false
+    def tasks
+      Task.all
     end
   end
 end

--- a/app/graphql/types/task_type.rb
+++ b/app/graphql/types/task_type.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Types
+  class TaskType < Types::BaseObject
+    field :id, ID, null: false
+    field :title, String
+    field :content, String
+    field :user, Types::UserType, null: false
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+  end
+end

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Types
+  class UserType < Types::BaseObject
+    field :id, ID, null: false
+    field :email, String, null: false
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+  end
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -7,11 +7,12 @@
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  user_id    :bigint           not null
+#  user_id    :uuid             not null
 #
 # Indexes
 #
 #  index_tasks_on_user_id  (user_id)
 #
 class Task < ApplicationRecord
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,5 @@
 #  updated_at :datetime         not null
 #
 class User < ApplicationRecord
+  has_many :tasks
 end

--- a/db/migrate/20220929060827_create_tasks.rb
+++ b/db/migrate/20220929060827_create_tasks.rb
@@ -3,7 +3,7 @@ class CreateTasks < ActiveRecord::Migration[7.0]
     create_table :tasks, id: :uuid do |t|
       t.string :title
       t.text :content
-      t.references :user, null: false
+      t.references :user, type: :uuid, null: false
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,7 +17,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_29_060827) do
   create_table "tasks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "title"
     t.text "content"
-    t.bigint "user_id", null: false
+    t.uuid "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_tasks_on_user_id"

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -7,7 +7,7 @@
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  user_id    :bigint           not null
+#  user_id    :uuid             not null
 #
 # Indexes
 #


### PR DESCRIPTION
- taskテーブルのuser_idカラムがbigintだとエラーになるため、uuidを明示して指定する必要があったため対応。下記記事参照
    - [Rails の UUIDプライマリキーを試す](https://qiita.com/HeRo/items/2816e27fb3066db6c4e6)
- userとtaskのSELECTとCREATEが出来るようにした
- 下記記事参照
    - [Rails + GraphQLでAPI作成](https://zenn.dev/slowhand/articles/4fe99377185100)
    - [【Rails】graphql-rubyでAPIを作成](https://qiita.com/k-penguin-sato/items/07fef2f26fd6339e0e69)
```
# generate objectについてはDBテーブル作成済みのため下記で対応
bundle exec rails g graphql:object User
bundle exec rails g graphql:object Task
# Createのmutationを下記で作成
bundle exec rails g graphql:mutation CreateUser
bundle exec rails g graphql:mutation CreateTask
```